### PR TITLE
Add endpoints for Users, UserReview, UserFollows

### DIFF
--- a/db_schema/init_tables.sql
+++ b/db_schema/init_tables.sql
@@ -73,7 +73,6 @@ LOAD DATA
     IGNORE 1 LINES;
 -- 
 
-
 -- Genres
 create table Genres (
 	tconst varchar(255),
@@ -138,6 +137,41 @@ LOAD DATA
 	LOCAL INFILE '/MY/ABSOLUTE/PATH/TO/data/processed/writers.tsv' 
     INTO TABLE Writers
     IGNORE 1 LINES;
+
+-- User table
+create table Users (
+    userId varchar(255) primary key,
+    username varchar(255),
+    email varchar(255),
+    password varchar(255)
+);
+-- Define a trigger to return the userId after insertion into Users
+CREATE TRIGGER ai_Users
+AFTER INSERT ON Users
+FOR EACH ROW
+SET @last_uuid = NEW.userId;
+
+
+-- User review table
+create table UserReview (
+	reviewId varchar(255) primary key,
+    userId varchar(255) not null,
+    tconst varchar(255) not null,
+    rating float check (rating between 0.0 and 10.0),
+    description text,
+    foreign key (userId) references Users(userId),
+	foreign key (tconst) references TitleBasics(tconst)
+);
+
+create table UserFollows (
+    userId varchar(255) not null,
+    followsUserId varchar(255) not null,
+    primary key (userId, followsUserId),
+    foreign key (userId) references Users(userId),
+    foreign key (followsUserId) references Users(userId),
+    -- users cannot follow themselves
+    constraint columns_cannot_equal check (userId <> followsUserId)
+);
 
 show tables;
 

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,0 +1,84 @@
+var UserSql = require("../sql/userSql")
+
+/* Register user with username, email and password
+Example request:
+{
+  "username": "myuser",
+  "email": "my@email.com"
+  "password": "mypass"
+}
+
+Expected response:
+200: User was created successfully
+400: User already exists
+*/
+exports.register = function(req, res, connection) {
+  let data = req.body;
+  let [username, email, password] = [data.username, data.email, data.password]
+
+  connection.query(UserSql.register, [username, email, password], function (error, results, fields) {
+    if (error) {
+      res.status(400)
+      res.send(JSON.stringify(error))
+      return;
+
+    }
+
+    // The sql query has 4 statements
+    // we are interested in the first result of the third line executed
+    console.log("New user: ", results[2][0]);
+
+    res.send(JSON.stringify({
+      "message": "Successfully registered user " + username,
+      "data": {
+        "userId": results[2][0].userId
+      }
+    }));
+  });
+}
+
+
+/* Login user with username and password
+Example request:
+{
+  "username": "myuser",
+  "password": "mypass"
+}
+
+Expected response:
+200: User was created successfully
+400: User already exists
+*/
+exports.login = function(req, res, connection) {
+  let data = req.body;
+  let [username, password] = [data.username, data.password]
+
+  connection.query(UserSql.login, [username, password], function (error, results, fields) {
+    if (error) {
+      res.status(400)
+      res.send(JSON.stringify(error))
+      return;
+
+    }
+    console.log("The solution is: ", results[0]);
+    if (results[0].loginSucceeded == 0) {
+
+      res.send(JSON.stringify({
+        "message": `Failed login for user ${username}: Incorrect username or password.`,
+        "data": {
+          "username": username
+        }
+      }));
+
+    } else {
+      res.send(JSON.stringify({
+        "message": "Successful login from user " + username,
+        "data": {
+          "username": username
+        }
+      }));
+
+    }
+
+  });
+}

--- a/server/controllers/userFollowsController.js
+++ b/server/controllers/userFollowsController.js
@@ -1,0 +1,103 @@
+UserFollowSql = require("../sql/userFollowsSql")
+
+/* Register user with username, email and password
+Example request:
+{
+  "userId": "625f1823-bb7d-11ed-bcfe-04d4c4ab8f25",
+  "userFollowsId": "625f1823-0000-11ed-bcfe-04d4c4ab8f25"
+}
+
+Expected response:
+200: Follow succeeded
+400: Follow failed
+*/
+exports.createFollower = function(req, res, connection) {
+  let data = req.body;
+  connection.query(UserFollowSql.createFollower, 
+        [data.userId, data.userFollowsId], 
+    function (error, results, fields) {
+    if (error) {
+      res.status(400)
+      res.send(JSON.stringify(error))
+      return;
+    }
+
+    res.send(JSON.stringify({
+      "message": `User ${data.userId} successfully followed ${data.userFollowsId}`,
+      "data": {}
+    }));
+  });
+}
+
+/*
+Unfollow a user
+Request and response same as following a user
+*/
+exports.deleteFollower = function(req, res, connection) {
+  let data = req.body;
+  connection.query(UserFollowSql.deleteFollower, 
+        [data.userId, data.userFollowsId], 
+    function (error, results, fields) {
+    if (error) {
+      res.status(400)
+      res.send(JSON.stringify(error))
+      return;
+    }
+
+    res.send(JSON.stringify({
+      "message": `User ${data.userId} successfully unfollowed ${data.userFollowsId}`,
+      "data": {}
+    }));
+  });
+
+}
+
+/*
+Returns a list of followers and their usernames
+Example request:
+{
+    "userId": "625f1823-bb7d-11ed-bcfe-04d4c4ab8f25"
+}
+
+Example response:
+{
+    "message": "Got follower list for f0584f44-bba4-11ed-bcfe-04d4c4ab8f25",
+    "data": {
+        "count": 2,
+        "followers": [
+            {
+                "userId": "e5214e37-bba4-11ed-bcfe-04d4c4ab8f25",
+                "username": "user5"
+            },
+            {
+                "userId": "f0584f44-bba4-11ed-bcfe-04d4c4ab8f25",
+                "username": "user5"
+            }
+        ]
+    }
+}
+*/
+exports.getFollowerList = function(req, res, connection) {
+  let data = req.body;
+  let userId = req.params.userId
+  console.log(`userID is ${userId}`)
+
+  connection.query(UserFollowSql.getFollowerList, 
+        [userId], 
+    function (error, results, fields) {
+    if (error) {
+      res.status(400)
+      res.send(JSON.stringify(error))
+      return;
+    }
+    console.log(results)
+
+    res.send(JSON.stringify({
+      "message": `Got follower list for ${data.userId}`,
+      "data": {
+        "count": results.length,
+        "followers": results
+      }
+    }));
+  });
+}

--- a/server/controllers/userReviewController.js
+++ b/server/controllers/userReviewController.js
@@ -1,0 +1,33 @@
+var UserReviewSql = require("../sql/userReviewSql")
+
+/*
+Create a review for a given user and title
+Example request
+{
+    "userId": "625f1823-bb7d-11ed-bcfe-04d4c4ab8f25",
+    "titleId": "tt0000001",
+    "rating": 9.8,
+    "description": "Great movie"
+}
+*/
+
+exports.createReview = function(req, res, connection) {
+  let data = req.body;
+  connection.query(UserReviewSql.createReview, 
+        [data.userId, data.titleId, data.rating, data.description], 
+    function (error, results, fields) {
+    if (error) {
+      res.status(400)
+      res.send(JSON.stringify(error))
+      return;
+    }
+
+    res.send(JSON.stringify({
+      "message": "Successfully created review",
+      "data": {
+        "reviewId": results[0]
+      }
+    }));
+  });
+}
+

--- a/server/index.js
+++ b/server/index.js
@@ -1,9 +1,20 @@
+var bodyParser = require('body-parser')
 const express = require("express");
 require("dotenv").config();
 var cors = require("cors");
 
+var ReviewController = require("./controllers/userReviewController")
+var UserController = require("./controllers/userController")
+var FollowController = require("./controllers/userFollowsController")
+
+
+var TitlesSql = require("./sql/titlesSql")
+
 const app = express();
-app.use(cors({ credentials: true, origin: "http://localhost:3000" }));
+app.use(cors({ credentials: true, origin: "http://localhost:5000" }));
+app.use(bodyParser.urlencoded({ extended: false }))
+app.use(bodyParser.json())
+
 const PORT = 5000;
 
 var mysql = require("mysql2");
@@ -11,12 +22,13 @@ var connection = mysql.createConnection({
   host: "localhost",
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
-  database: "hello_world",
+  database: "db",
+  multipleStatements: true
 });
 connection.connect();
 
 app.get("/", (req, res) => {
-  connection.query("SELECT * from persons", function (error, results, fields) {
+  connection.query(TitlesSql.getAll, function (error, results, fields) {
     if (error) {
       connection.end();
       throw error;
@@ -26,6 +38,39 @@ app.get("/", (req, res) => {
     res.send(results[0]);
   });
 });
+
+// Users
+// Create user
+app.post('/register', (req, res) => {
+  UserController.register(req, res, connection)
+})
+
+// Login
+app.post('/login', (req, res) => {
+  UserController.login(req, res, connection)
+})
+
+// UserReview
+// Create review
+app.post("/review", (req, res) => {
+  ReviewController.createReview(req, res, connection)
+})
+
+// UserFollow
+// follow a user
+app.post("/followers/follow", (req, res) => {
+  FollowController.createFollower(req, res, connection)
+})
+
+// unfollow a user
+app.post("/followers/unfollow", (req, res) => {
+  // FollowController.deleteFollower(req, res, connection)
+})
+
+// get follower list
+app.get("/followers/get/:userId", (req, res) => {
+  FollowController.getFollowerList(req, res, connection)
+})
 
 app.listen(PORT, (error) => {
   if (!error)

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/server/sql/titlesSql.js
+++ b/server/sql/titlesSql.js
@@ -1,0 +1,3 @@
+exports.getAll = `
+    select * from TitleBasics
+`

--- a/server/sql/userFollowsSql.js
+++ b/server/sql/userFollowsSql.js
@@ -1,0 +1,16 @@
+exports.createFollower = `
+    insert into UserFollows values (?, ?)
+`
+
+// Get a list of users (userId, userName) that follow a user
+exports.getFollowerList = `
+    select u.userId, u.username from UserFollows as uf
+    join Users as u on uf.userId=u.userId
+    where followsUserId=?
+`
+
+// Unfollow a user
+exports.deleteFollower = `
+    delete from UserFollows
+    where userId=? and followsUserId=?
+`

--- a/server/sql/userReviewSql.js
+++ b/server/sql/userReviewSql.js
@@ -1,0 +1,19 @@
+exports.getAll = `
+select * from UserReview
+`
+
+// Get all reviews for a title
+exports.getForTitle = `
+select * from UserReview
+    where userId=?
+`
+// Get all reviews made by a user
+exports.getForUser = `
+select * from UserReview
+    where tconst=?    
+`
+
+exports.createReview = `
+insert into UserReview
+values (uuid(), ?, ?, ?, ?)
+`

--- a/server/sql/userSql.js
+++ b/server/sql/userSql.js
@@ -1,0 +1,21 @@
+exports.getAll = `
+    select * from Users;
+`
+
+// Register a user with username and password
+exports.register = `
+START TRANSACTION;
+    insert into Users VALUES (uuid(), ?, ?, ?);
+    select @last_uuid as userId;
+COMMIT;
+`
+
+// Login will check if there exists a user with
+// username and password
+// if query returns empty, login attempt failed
+// otherwise we expect query to return at most 1 row
+exports.login = `
+    select exists( select * from Users
+    where username=?
+    and password=?) as loginSucceeded;
+`


### PR DESCRIPTION
Modfies init_tables.sql to add new tables Users, UserReview, UserFollows. **Note: these tables do not depend on the IMDB dataset**

Adds backend endpoints for CRUD operations on Users, UserReview, and UserFollows tables:

Users:
- `POST /register`: Register a new user
- `POST /login`: Attempt a login for a given username/password combination

UserReview:
- `POST /review`: Create a review for a given title by a user

UserFollows:
- `POST /followers/follow`: Follow another user by a user
- `POST /followers/unfollow`: Unfollow another user from a user  
- `GET /followers/get/{userId}` Get a list of followers for a given user

API documentation/examples here: https://www.postman.com/material-operator-533618/workspace/1f5cefe3-cccb-4d96-bf06-2b2f35083f12/collection/22807733-6fbec6cb-5b74-4e91-a33f-90726ad8f4ab?action=share&creator=22807733
